### PR TITLE
Start `init` from `phusion/baseimage` before anything else

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ ENV PATH=/opt/conda/bin:$PATH \
 
 ADD docker /usr/share/docker
 
-ENTRYPOINT [ "/usr/share/docker/entrypoint.sh" ]
+ENTRYPOINT [ "/sbin/my_init", "--", "/usr/share/docker/entrypoint.sh" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Fixes https://github.com/jakirkham/docker_phusion_baseimage_drmaa_conda/issues/1.

Runs it in the `ENTRYPOINT`. This guarantees that it will run before anything else. All other entrypoint scripts can be passed as arguments.
