### PR TITLE
Remove `miniconda.sh` after install.

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -22,6 +22,7 @@ apt-get clean
 cd /usr/share/miniconda
 curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > miniconda.sh
 bash miniconda.sh -b -p /opt/conda
+rm miniconda.sh
 export PATH="/opt/conda/bin:${PATH}"
 source activate root
 conda config --set show_channel_urls True


### PR DESCRIPTION
Apparently we weren't remove this and so it was in the commit for the `miniconda` install. I think the initial reason was to inspect the image if something went wrong. However, that happens so rarely and should happen before deletion. This should make for a notable size reduction.
